### PR TITLE
Fetch PDF from single URL

### DIFF
--- a/app/endpointController.py
+++ b/app/endpointController.py
@@ -13,7 +13,7 @@ ocr_processor = OCRProcessor()
 json_formatter = JSONFormatter()
 
 
-@api_router.get("/process-pdf", response_model=list)
+@api_router.get("/api/v1/extract", response_model=list)
 async def process_pdf(url: str):
     try:
         pdf_data = pdf_fetcher.fetch_pdf(url)

--- a/app/endpointController.py
+++ b/app/endpointController.py
@@ -14,9 +14,9 @@ json_formatter = JSONFormatter()
 
 
 @api_router.get("/process-pdf", response_model=list)
-async def process_pdf(country: str, train_station: str, day: date):
+async def process_pdf(url: str):
     try:
-        pdf_data = pdf_fetcher.fetch_pdf(country, train_station, day)
+        pdf_data = pdf_fetcher.fetch_pdf(url)
 
         extracted_text = ocr_processor.extract_text(pdf_data)
 

--- a/app/pdfFetcher.py
+++ b/app/pdfFetcher.py
@@ -15,15 +15,9 @@ class PDFFetcher:
         if not self.base_url:
             raise ValueError("Environment variable 'PDF_API_BASE_URL' is not set or empty.")
 
-    def fetch_pdf(self, country: str, train_station: str, day: date) -> str:
-        params = {
-            "date": day.strftime("%m/%d/%Y"),
-        }
-
-        url = self.base_url.format(country=country, train_station=train_station)
-
+    def fetch_pdf(self, url: str) -> str:
         try:
-            response = requests.get(url, params=params, headers={"Accept": self.PDF_CONTENT_TYPE})
+            response = requests.get(url, headers={"Accept": self.PDF_CONTENT_TYPE})
             response.raise_for_status()
 
             content_type = response.headers.get("Content-Type")

--- a/tests/extract_test.py
+++ b/tests/extract_test.py
@@ -28,7 +28,7 @@ def mock_pdf_fetcher():
 
 
 def test_can_extract_data_and_send_json(mock_pdf_fetcher):
-    response = client.get("/process-pdf/?train_station=Yverdon-les-bains&day=2024-12-09")
+    response = client.get("/api/v1/extract/?url=https%3A%2F%2Fs3.eu-south-1.amazonaws.com%2Fdev.data.generator.cld.education%2F2025-01-17%2F8504200.pdf%3FX-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3DAKIA2KFJKL4O35LD5P3Z%252F20250122%252Feu-south-1%252Fs3%252Faws4_request%26X-Amz-Date%3D20250122T093428Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26X-Amz-Signature%3D199ad4b3a0387e8a86199f3494695f9a12d215ec3a058fa2a845d6915b8a725a")
 
     assert response.status_code == 200
     assert response.json() == EXPECTED_JSON
@@ -37,7 +37,7 @@ def test_can_extract_data_and_send_json(mock_pdf_fetcher):
 def test_pdf_not_existing(mock_pdf_fetcher):
     mock_pdf_fetcher.side_effect = ValueError("The pdf is not existing")
 
-    response = client.get("/process-pdf/?train_station=Lausanne&day=2024-12-10")
+    response = client.get("/api/v1/extract/?url=https%3A%2F%2Fs3.eu-south-1.amazonaws.com%2Fdev.data.generator.cld.education%2F2025-01-17%2F8504200.pdf%3FX-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3DAKIA2KFJKL4O35LD5P3Z%252F20250122%252Feu-south-1%252Fs3%252Faws4_request%26X-Amz-Date%3D20250122T093428Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26X-Amz-Signature%3D199ad4b3a0387e8a86199f3494695f9a12d215ec3a058fa2a845d6915b8a725a")
 
     assert response.status_code == 400
     assert response.json() == {"detail": "The pdf is not existing"}
@@ -46,7 +46,7 @@ def test_pdf_not_existing(mock_pdf_fetcher):
 def test_invalid_pdf(mock_pdf_fetcher):
     mock_pdf_fetcher.side_effect = ValueError("Fetched content is not a PDF.")
 
-    response = client.get("/process-pdf/?train_station=Yverdon-les-bains&day=2024-12-09")
+    response = client.get("/api/v1/extract/?url=https%3A%2F%2Fs3.eu-south-1.amazonaws.com%2Fdev.data.generator.cld.education%2F2025-01-17%2F8504200.pdf%3FX-Amz-Algorithm%3DAWS4-HMAC-SHA256%26X-Amz-Credential%3DAKIA2KFJKL4O35LD5P3Z%252F20250122%252Feu-south-1%252Fs3%252Faws4_request%26X-Amz-Date%3D20250122T093428Z%26X-Amz-Expires%3D3600%26X-Amz-SignedHeaders%3Dhost%26X-Amz-Signature%3D199ad4b3a0387e8a86199f3494695f9a12d215ec3a058fa2a845d6915b8a725a")
 
     assert response.status_code == 400
     assert response.json() == {"detail": "Fetched content is not a PDF."}


### PR DESCRIPTION
This pull request includes changes to simplify the process of fetching and processing PDFs by modifying the function parameters and removing unnecessary arguments. The most important changes include updating the endpoint controller and the PDF fetcher class to use a single URL parameter instead of multiple parameters.

Endpoint controller update:

* [`app/endpointController.py`](diffhunk://#diff-194dd08ca5ffd3dedde5ba62310f29fd71c00de5324e3fb8c9e2d855a54a9523L17-R19): Modified the `process_pdf` function to accept a single `url` parameter instead of `country`, `train_station`, and `day`.

PDF fetcher class update:

* [`app/pdfFetcher.py`](diffhunk://#diff-ae10a78aa3a649fa3464ed204e85664372bada83d34d1a21e21116a04be67f8cL18-R20): Updated the `fetch_pdf` method to accept a single `url` parameter and removed the logic for constructing the URL from `country`, `train_station`, and `day`.